### PR TITLE
Convert math blocks to $$ for Obsidian compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Over the past years working in AI/ML, I filled notebooks with intuition first, r
 - Suggest topics via GitHub issues.
 - PR corrections and better intuition.
 - Create SVG images in `../images/` for all diagrams. 
-- For equations, use ` ```math ` fenced code blocks (NOT `$$`)
-- For display math — GitHub escapes `\\` inside `$$`, breaking matrices. 
-- Inline math `$...$` is fine for simple expressions but move anything with `\\` into a ` ```math ` block. 
+- For display math, use `$$...$$` blocks.
+- Inline math `$...$` is fine for simple expressions.
 - Use `\ast` instead of `*` for conjugate/adjoint in inline math.

--- a/chapter 01: vectors/05. basis and duality.md
+++ b/chapter 01: vectors/05. basis and duality.md
@@ -35,9 +35,9 @@
 
 - For every basis $\{\mathbf{e}_1, \mathbf{e}_2, \ldots, \mathbf{e}_n\}$, there is a corresponding **dual basis** $\{\mathbf{e}_1^\ast, \mathbf{e}_2^\ast, \ldots, \mathbf{e}_n^\ast\}$. Each dual basis vector extracts exactly one coordinate:
 
-```math
+$$
 \mathbf{e}_i^\ast(\mathbf{e}_j) = \delta_{ij} = \begin{cases} 1 & \text{if } i = j \\ 0 & \text{if } i \neq j \end{cases}
-```
+$$
 
 - $\mathbf{e}_1^\ast$ returns 1 when applied to $\mathbf{e}_1$ and 0 for everything else. It perfectly isolates the first coordinate.
 

--- a/chapter 02: matrices/01. matrix properties.md
+++ b/chapter 02: matrices/01. matrix properties.md
@@ -2,17 +2,17 @@
 
 - At its core, a **matrix** is a rectangular grid of numbers arranged in rows and columns. If a vector is a single list of numbers, a matrix is a table of them.
 
-```math
+$$
 A = \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \end{bmatrix}
-```
+$$
 
 - You can also think of a matrix as a stack of vectors.
 
 - If a single person is described by the vector $[\text{age}, \text{height}, \text{weight}]$, then three people form a matrix where each row is one person:
 
-```math
+$$
 \begin{bmatrix} 25 & 170 & 65 \\ 30 & 180 & 80 \\ 22 & 160 & 55 \end{bmatrix}
-```
+$$
 
 - This matrix has 3 rows and 3 columns, so we call it a $3 \times 3$ matrix.
 
@@ -20,9 +20,9 @@ A = \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \end{bmatrix}
 
 - The **transpose** of a matrix flips it along its diagonal, turning rows into columns and columns into rows. If $A$ is $m \times n$, then $A^T$ is $n \times m$.
 
-```math
+$$
 A = \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \end{bmatrix} \quad \Rightarrow \quad A^T = \begin{bmatrix} 1 & 4 \\ 2 & 5 \\ 3 & 6 \end{bmatrix}
-```
+$$
 
 - Multiplying a matrix by its transpose always gives a square matrix: $AA^T$ is $m \times m$ and $A^TA$ is $n \times n$.
 
@@ -38,15 +38,15 @@ A = \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \end{bmatrix} \quad \Rightarrow \quad
 
 - For example, the following matrix has rank 2 because neither row is a multiple of the other:
 
-```math
+$$
 \begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix}
-```
+$$
 
 But this matrix has rank 1 because the second row is just twice the first, so it adds no new information:
 
-```math
+$$
 \begin{bmatrix} 1 & 2 \\ 2 & 4 \end{bmatrix}
-```
+$$
 
 - A $5 \times 3$ matrix can have rank at most 3. If some rows are just scaled or combined versions of others, the rank drops. A matrix with maximum possible rank is called **full rank**.
 
@@ -66,17 +66,17 @@ But this matrix has rank 1 because the second row is just twice the first, so it
 
 - The **determinant** of a square matrix is a single number that captures how the matrix scales space. Think of a $2 \times 2$ matrix as transforming a unit square into a parallelogram. The determinant is the area of that parallelogram (with a sign).
 
-```math
+$$
 \det\begin{bmatrix} a & b \\ c & d \end{bmatrix} = ad - bc
-```
+$$
 
 ![Determinant: the area scaling factor of a linear transformation](../images/determinant.svg)
 
 - For example:
 
-```math
+$$
 \det\begin{bmatrix} 2 & 1 \\ 0 & 3 \end{bmatrix} = 2 \cdot 3 - 1 \cdot 0 = 6
-```
+$$
 
 The transformation stretches the unit square into a parallelogram with area 6.
 
@@ -94,9 +94,9 @@ The transformation stretches the unit square into a parallelogram with area 6.
 
 - For a $2 \times 2$ matrix, the inverse has a direct formula:
 
-```math
+$$
 \begin{bmatrix} a & b \\ c & d \end{bmatrix}^{-1} = \frac{1}{ad - bc}\begin{bmatrix} d & -b \\ -c & a \end{bmatrix}
-```
+$$
 
 Notice the determinant in the denominator, which is why singular matrices (determinant zero) have no inverse.
 
@@ -106,21 +106,21 @@ Notice the determinant in the denominator, which is why singular matrices (deter
 
 - For example, the following matrix has condition number $10^8$. One direction is scaled normally while the other is nearly squashed to zero, so small perturbations along that direction get wildly distorted:
 
-```math
+$$
 \begin{bmatrix} 1 & 0 \\ 0 & 10^{-8} \end{bmatrix}
-```
+$$
 
 - Just as vectors have norms (length), matrices have **norms** that measure their "size." The most common is the **Frobenius norm**, which treats the matrix as a long vector and computes its length:
 
-```math
+$$
 \|A\|_F = \sqrt{\sum_{i}\sum_{j} A_{ij}^2}
-```
+$$
 
 - For example:
 
-```math
+$$
 \left\|\begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix}\right\|_F = \sqrt{1 + 4 + 9 + 16} = \sqrt{30} \approx 5.48
-```
+$$
 
 - The **spectral norm** $\|A\|_2$ is the largest singular value of $A$. It measures the maximum amount the matrix can stretch any unit vector. In ML, matrix norms are used for weight regularisation (penalising large weights) and monitoring training stability.
 
@@ -128,9 +128,9 @@ Notice the determinant in the denominator, which is why singular matrices (deter
 
 - For example, the following matrix is positive definite:
 
-```math
+$$
 A = \begin{bmatrix} 2 & 1 \\ 1 & 3 \end{bmatrix}
-```
+$$
 
 Pick any vector, say $\mathbf{x} = [1, -1]^T$: $\mathbf{x}^T A \mathbf{x} = 2 - 1 - 1 + 3 = 3 > 0$. No matter which non-zero $\mathbf{x}$ you try, you always get a positive result.
 

--- a/chapter 02: matrices/02. matrix types.md
+++ b/chapter 02: matrices/02. matrix types.md
@@ -6,29 +6,29 @@
 
 - The **identity matrix** $I$ is a square matrix with 1s on the diagonal and 0s everywhere else. It is the "do nothing" transformation: $AI = IA = A$ for any compatible matrix $A$.
 
-```math
+$$
 I = \begin{bmatrix} 1 & 0 & 0 \\ 0 & 1 & 0 \\ 0 & 0 & 1 \end{bmatrix}
-```
+$$
 
 - The **zero matrix** $O$ has all elements equal to zero. It maps every vector to the zero vector, destroying all information.
 
 - A **diagonal matrix** is all zeros except on the main diagonal. Multiplying a vector by a diagonal matrix simply scales each component independently, making it very efficient.
 
-```math
+$$
 D = \begin{bmatrix} 3 & 0 \\ 0 & 7 \end{bmatrix}
-```
+$$
 
 - A **symmetric matrix** equals its own transpose: $A = A^T$, meaning $A_{ij} = A_{ji}$. Symmetric matrices have the special property that their eigenvectors are always perpendicular to each other. Covariance matrices are always symmetric.
 
-```math
+$$
 S = \begin{bmatrix} 3 & -1 \\ -1 & 6 \end{bmatrix}
-```
+$$
 
 - A **triangular matrix** has all zeros on one side of the diagonal. **Lower triangular** has zeros above, **upper triangular** has zeros below. They are essential for solving systems of equations efficiently through forward or back substitution.
 
-```math
+$$
 L = \begin{bmatrix} 2 & 0 & 0 \\ 1 & 3 & 0 \\ -1 & 2 & 4 \end{bmatrix} \qquad U = \begin{bmatrix} 5 & -1 & 2 \\ 0 & 1 & 3 \\ 0 & 0 & -2 \end{bmatrix}
-```
+$$
 
 - The determinant of a triangular matrix is simply the product of its diagonal elements.
 
@@ -50,23 +50,23 @@ L = \begin{bmatrix} 2 & 0 & 0 \\ 1 & 3 & 0 \\ -1 & 2 & 4 \end{bmatrix} \qquad U 
 
 - For example, the matrix below moves element 3 to position 1, element 1 to position 2, and element 2 to position 3:
 
-```math
+$$
 P = \begin{bmatrix} 0 & 0 & 1 \\ 1 & 0 & 0 \\ 0 & 1 & 0 \end{bmatrix}
-```
+$$
 
 - A **Toeplitz matrix** has the same value along every diagonal (upper-left to lower-right). Notice how each diagonal is constant:
 
-```math
+$$
 T = \begin{bmatrix} a & b & c \\ d & a & b \\ e & d & a \end{bmatrix}
-```
+$$
 
 - This structure appears in signal processing and convolution, because sliding a fixed filter across a signal is equivalent to multiplying by a Toeplitz matrix.
 
 - A **circulant matrix** is a special Toeplitz matrix where each row is a cyclic shift of the one above. When a row reaches the end, it wraps around:
 
-```math
+$$
 C = \begin{bmatrix} 1 & 3 & 2 \\ 2 & 1 & 3 \\ 3 & 2 & 1 \end{bmatrix}
-```
+$$
 
 - Circulant matrices are closely connected to the discrete Fourier transform (DFT) and are central to how circular convolution works.
 
@@ -80,31 +80,31 @@ C = \begin{bmatrix} 1 & 3 & 2 \\ 2 & 1 & 3 \\ 3 & 2 & 1 \end{bmatrix}
 
 - A **nilpotent matrix** satisfies $A^k = O$ (the zero matrix) for some power $k$. Apply the transformation enough times and everything collapses to zero. For example:
 
-```math
+$$
 \begin{bmatrix} 0 & 1 \\ 0 & 0 \end{bmatrix}^2 = \begin{bmatrix} 0 & 0 \\ 0 & 0 \end{bmatrix}
-```
+$$
 
 - A **Boolean matrix** (or binary matrix) contains only 0s and 1s. It represents yes/no relationships. For example, in a graph with 3 nodes, the **adjacency matrix** records which nodes are connected:
 
-```math
+$$
 B = \begin{bmatrix} 0 & 1 & 1 \\ 1 & 0 & 0 \\ 1 & 0 & 0 \end{bmatrix}
-```
+$$
 
 - Here, node 1 connects to nodes 2 and 3, but nodes 2 and 3 are not connected to each other.
 
 - A **Vandermonde matrix** is built from consecutive powers of a set of values. Given values $x_1, x_2, x_3$:
 
-```math
+$$
 V = \begin{bmatrix} 1 & x_1 & x_1^2 \\ 1 & x_2 & x_2^2 \\ 1 & x_3 & x_3^2 \end{bmatrix}
-```
+$$
 
 - This structure appears in polynomial interpolation: finding the unique polynomial that passes through a given set of points.
 
 - A **Hessenberg matrix** is "almost" triangular, with zeros below the first subdiagonal:
 
-```math
+$$
 H = \begin{bmatrix} 4 & 2 & 1 \\ 3 & 5 & -1 \\ 0 & 1 & 6 \end{bmatrix}
-```
+$$
 
 - It is a useful intermediate form for computing eigenvalues efficiently. Reducing a matrix to Hessenberg form first makes iterative algorithms converge faster.
 

--- a/chapter 02: matrices/03. operations.md
+++ b/chapter 02: matrices/03. operations.md
@@ -4,21 +4,21 @@
 
 - For addition, both matrices must have the same dimensions, and you add element by element:
 
-```math
+$$
 \begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix} + \begin{bmatrix} 5 & 6 \\ 7 & 8 \end{bmatrix} = \begin{bmatrix} 6 & 8 \\ 10 & 12 \end{bmatrix}
-```
+$$
 
 - For scalar multiplication, you multiply every element by the scalar:
 
-```math
+$$
 3 \times \begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix} = \begin{bmatrix} 3 & 6 \\ 9 & 12 \end{bmatrix}
-```
+$$
 
 - The simplest thing you can do with a matrix is multiply it by a vector. **Matrix-vector multiplication** $A\mathbf{x}$ combines the columns of $A$ using the entries of $\mathbf{x}$ as weights:
 
-```math
+$$
 \begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix} \begin{bmatrix} 5 \\ 6 \end{bmatrix} = 5 \begin{bmatrix} 1 \\ 3 \end{bmatrix} + 6 \begin{bmatrix} 2 \\ 4 \end{bmatrix} = \begin{bmatrix} 17 \\ 39 \end{bmatrix}
-```
+$$
 
 - This is the core operation in ML. Every neural network layer computes $A\mathbf{x} + \mathbf{b}$: a matrix times an input vector, plus a bias.
 
@@ -34,9 +34,9 @@ $$C_{ij} = \sum_{k=1}^{n} A_{ik} B_{kj}$$
 
 - A useful special case: multiplying a matrix by its transpose always gives a square matrix. $AA^T$ is $m \times m$ and $A^TA$ is $n \times n$:
 
-```math
+$$
 \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \end{bmatrix} \begin{bmatrix} 1 & 4 \\ 2 & 5 \\ 3 & 6 \end{bmatrix} = \begin{bmatrix} 14 & 32 \\ 32 & 77 \end{bmatrix}
-```
+$$
 
 - Matrix multiplication has important rules:
 
@@ -50,17 +50,17 @@ $$C_{ij} = \sum_{k=1}^{n} A_{ik} B_{kj}$$
 
 - The **Hadamard product** (element-wise product) multiplies two matrices of the same size entry by entry, written $A \odot B$:
 
-```math
+$$
 \begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix} \odot \begin{bmatrix} 5 & 6 \\ 7 & 8 \end{bmatrix} = \begin{bmatrix} 5 & 12 \\ 21 & 32 \end{bmatrix}
-```
+$$
 
 - Unlike standard matrix multiplication, the Hadamard product is commutative ($A \odot B = B \odot A$) and requires both matrices to have the same dimensions. It is used heavily in ML for gating: multiplying element-wise by a mask of values between 0 and 1 controls how much of each entry "passes through."
 
 - The **outer product** of two vectors $\mathbf{u}$ and $\mathbf{v}$ produces a matrix: $\mathbf{u}\mathbf{v}^T$. Each entry is the product of one element from $\mathbf{u}$ and one from $\mathbf{v}$:
 
-```math
+$$
 \begin{bmatrix} 1 \\ 2 \\ 3 \end{bmatrix} \begin{bmatrix} 4 & 5 \end{bmatrix} = \begin{bmatrix} 4 & 5 \\ 8 & 10 \\ 12 & 15 \end{bmatrix}
-```
+$$
 
 - The result always has rank 1, because every row is a scaled version of $\mathbf{v}^T$. Any matrix can be written as a sum of rank-1 outer products, which is exactly what SVD does (covered in decompositions).
 
@@ -74,9 +74,9 @@ $$C_{ij} = \sum_{k=1}^{n} A_{ik} B_{kj}$$
 
 - For example, the matrix:
 
-```math
+$$
 A = \begin{bmatrix} 5 & 0 & 0 & 2 \\ 0 & 0 & 3 & 0 \\ 0 & 0 & 0 & -1 \end{bmatrix}
-```
+$$
 
 - Is stored as: values = [5, 2, 3, -1], columns = [0, 3, 2, 3], row offsets = [0, 2, 3, 4]. This skips all the zeros and makes sparse operations much faster.
 
@@ -84,9 +84,9 @@ A = \begin{bmatrix} 5 & 0 & 0 & 2 \\ 0 & 0 & 3 & 0 \\ 0 & 0 & 0 & -1 \end{bmatri
 
 - For example, say you are buying fruit. Apples cost $x_1$ dollars each and bananas cost $x_2$ dollars each. You know that 2 apples and 1 banana cost \$5, and 1 apple and 3 bananas cost \$10. In matrix form:
 
-```math
+$$
 \begin{bmatrix} 2 & 1 \\ 1 & 3 \end{bmatrix} \begin{bmatrix} x_1 \\ x_2 \end{bmatrix} = \begin{bmatrix} 5 \\ 10 \end{bmatrix}
-```
+$$
 
 - Multiplying the matrix by the vector row by row (each row dotted with $[x_1, x_2]^T$) gives two equations:
 
@@ -96,9 +96,9 @@ $$2x_1 + 1x_2 = 5 \qquad \text{(row 1)} \qquad \qquad x_1 + 3x_2 = 10 \qquad \te
 
 - Verify — it checks out:
 
-```math
+$$
 \begin{bmatrix} 2 & 1 \\ 1 & 3 \end{bmatrix} \begin{bmatrix} 1 \\ 3 \end{bmatrix} = \begin{bmatrix} 2 + 3 \\ 1 + 9 \end{bmatrix} = \begin{bmatrix} 5 \\ 10 \end{bmatrix}
-```
+$$
 
 - If $A$ has an inverse, the solution is simply $\mathbf{x} = A^{-1}\mathbf{b}$. But computing the inverse directly is expensive and numerically unstable. In practice, we use decompositions instead.
 

--- a/chapter 02: matrices/04. linear transformations.md
+++ b/chapter 02: matrices/04. linear transformations.md
@@ -13,9 +13,9 @@
 
 - For example, if
 
-```math
+$$
 A = \begin{bmatrix} 2 & 1 \\ 1 & 2 \end{bmatrix}
-```
+$$
 
   then $\hat{\mathbf{i}} = [1, 0]^T$ lands at $[2, 1]^T$ (column 1) and $\hat{\mathbf{j}} = [0, 1]^T$ lands at $[1, 2]^T$ (column 2). Every other vector is a combination of these two, so its output follows automatically.
 
@@ -27,29 +27,29 @@ A = \begin{bmatrix} 2 & 1 \\ 1 & 2 \end{bmatrix}
 
 - In 2D, the rotation matrix is:
 
-```math
+$$
 R(\theta) = \begin{bmatrix} \cos\theta & -\sin\theta \\ \sin\theta & \cos\theta \end{bmatrix}
-```
+$$
 
 - For $\theta = 90°$:
 
-```math
+$$
 R = \begin{bmatrix} 0 & -1 \\ 1 & 0 \end{bmatrix}
-```
+$$
 
   so $[1, 0]^T$ becomes $[0, 1]^T$. The vector pointing right now points up. Rotation matrices are orthogonal and always have determinant 1. When you rotate a photo on your phone, this is the exact matrix being applied to every pixel coordinate.
 
 - In 3D, there are separate rotation matrices for each axis. A robotic arm rotates each joint around a specific axis, and each joint is one rotation matrix. Rotation around the z-axis looks like the 2D case embedded in 3D:
 
-```math
+$$
 R_z(\theta) = \begin{bmatrix} \cos\theta & -\sin\theta & 0 \\ \sin\theta & \cos\theta & 0 \\ 0 & 0 & 1 \end{bmatrix}
-```
+$$
 
 - **Scaling** stretches or shrinks vectors along each axis independently:
 
-```math
+$$
 S(s_x, s_y) = \begin{bmatrix} s_x & 0 \\ 0 & s_y \end{bmatrix}
-```
+$$
 
 ![Scaling stretches each axis by a different factor](../images/scaling.svg)
 
@@ -57,17 +57,17 @@ S(s_x, s_y) = \begin{bmatrix} s_x & 0 \\ 0 & s_y \end{bmatrix}
 
 - **Reflection** flips vectors across an axis or line, like a mirror. Reflecting across the x-axis keeps the x-component and negates the y-component:
 
-```math
+$$
 \text{Ref}_x = \begin{bmatrix} 1 & 0 \\ 0 & -1 \end{bmatrix}
-```
+$$
 
 ![Reflection across the x-axis flips the y-component](../images/reflection.svg)
 
 - For example, $[3, 2]^T$ becomes $[3, -2]^T$. When your phone flips a selfie horizontally so text reads correctly, it is applying a reflection matrix. Reflecting across the line $y = x$ swaps the two components:
 
-```math
+$$
 \text{Ref}_{y=x} = \begin{bmatrix} 0 & 1 \\ 1 & 0 \end{bmatrix}
-```
+$$
 
 - Reflection matrices have determinant $-1$, confirming they flip orientation.
 
@@ -75,9 +75,9 @@ S(s_x, s_y) = \begin{bmatrix} s_x & 0 \\ 0 & s_y \end{bmatrix}
 
 - **Shearing** skews vectors along one axis proportionally to the other. A horizontal shear by factor $k$:
 
-```math
+$$
 \text{Sh}_x(k) = \begin{bmatrix} 1 & k \\ 0 & 1 \end{bmatrix}
-```
+$$
 
 ![Shearing slides the top sideways while the bottom stays fixed](../images/shearing.svg)
 
@@ -91,9 +91,9 @@ $$\mathbf{y} = A\mathbf{x} + \mathbf{t}$$
 
 - To represent this as a single matrix multiplication, we use **homogeneous coordinates**: add an extra 1 to every vector and use an $(n+1) \times (n+1)$ matrix:
 
-```math
+$$
 \begin{bmatrix} A & \mathbf{t} \\ \mathbf{0}^T & 1 \end{bmatrix} \begin{bmatrix} \mathbf{x} \\ 1 \end{bmatrix} = \begin{bmatrix} A\mathbf{x} + \mathbf{t} \\ 1 \end{bmatrix}
-```
+$$
 
 - Affine transformations preserve straight lines and parallelism, but not necessarily angles or lengths. Every object in a video game is positioned using affine transformations: rotate it, scale it, then place it at the right location, all encoded in a single matrix.
 
@@ -101,9 +101,9 @@ $$\mathbf{y} = A\mathbf{x} + \mathbf{t}$$
 
 - For example, the matrix
 
-```math
+$$
 \begin{bmatrix} 1 & 2 \\ 2 & 4 \end{bmatrix}
-```
+$$
 
   maps every 2D vector onto a single line, because both columns point in the same direction. The determinant is zero, information is lost, and the transformation cannot be undone.
 

--- a/chapter 02: matrices/05. decompositions.md
+++ b/chapter 02: matrices/05. decompositions.md
@@ -10,9 +10,9 @@
 
 - For example, to eliminate the first column below the pivot, subtract multiples of row 1 from the rows below:
 
-```math
+$$
 \begin{bmatrix} 2 & 1 & 5 \\ 4 & 3 & 7 \\ 6 & 5 & 9 \end{bmatrix} \xrightarrow{R_2 - 2R_1} \begin{bmatrix} 2 & 1 & 5 \\ 0 & 1 & -3 \\ 6 & 5 & 9 \end{bmatrix} \xrightarrow{R_3 - 3R_1} \begin{bmatrix} 2 & 1 & 5 \\ 0 & 1 & -3 \\ 0 & 2 & -6 \end{bmatrix}
-```
+$$
 
 - The goal is **row echelon form (REF)**: zeros below each pivot (the first nonzero entry in each row), with each pivot to the right of the one above it. The matrix becomes a staircase shape.
 
@@ -38,9 +38,9 @@
 
 - **Cholesky decomposition** factors it as $A = LL^T$, where $L$ is lower triangular. For example:
 
-```math
+$$
 \begin{bmatrix} 4 & 2 \\ 2 & 5 \end{bmatrix} = \begin{bmatrix} 2 & 0 \\ 1 & 2 \end{bmatrix} \begin{bmatrix} 2 & 1 \\ 0 & 2 \end{bmatrix}
-```
+$$
 
 - This is roughly twice as fast as LU and is guaranteed to be numerically stable. Think of it as a "square root" of the matrix.
 
@@ -56,9 +56,9 @@ $$A\mathbf{x} = \lambda\mathbf{x}$$
 
 - For example, with:
 
-```math
+$$
 A = \begin{bmatrix} 3 & 1 \\ 0 & 2 \end{bmatrix}
-```
+$$
 
   the vector $[1, 0]^T$ is an eigenvector with $\lambda = 3$ because $A[1, 0]^T = [3, 0]^T = 3[1, 0]^T$.
 

--- a/chapter 03: calculus/03. multivariate calculus.md
+++ b/chapter 03: calculus/03. multivariate calculus.md
@@ -52,9 +52,9 @@ $$D_{\mathbf{u}} f = \nabla f \cdot \mathbf{u}$$
 
 - So far, our functions produced a single output. But many functions produce multiple outputs. A function $\mathbf{F}: \mathbb{R}^n \to \mathbb{R}^m$ takes $n$ inputs and produces $m$ outputs. The **Jacobian matrix** organises all the partial derivatives of such a vector-valued function:
 
-```math
+$$
 J = \begin{bmatrix} \frac{\partial f_1}{\partial x_1} & \cdots & \frac{\partial f_1}{\partial x_n} \\ \vdots & \ddots & \vdots \\ \frac{\partial f_m}{\partial x_1} & \cdots & \frac{\partial f_m}{\partial x_n} \end{bmatrix}
-```
+$$
 
 - Each row of the Jacobian is the gradient of one output component. For a function with 3 inputs and 2 outputs, the Jacobian is a $2 \times 3$ matrix.
 
@@ -72,15 +72,15 @@ J = \begin{bmatrix} \frac{\partial f_1}{\partial x_1} & \cdots & \frac{\partial 
 
 - For a scalar function $f(x_1, \ldots, x_n)$, the Hessian is the $n \times n$ matrix of all second partial derivatives:
 
-```math
+$$
 H = \begin{bmatrix} \frac{\partial^2 f}{\partial x_1^2} & \frac{\partial^2 f}{\partial x_1 \partial x_2} & \cdots \\ \frac{\partial^2 f}{\partial x_2 \partial x_1} & \frac{\partial^2 f}{\partial x_2^2} & \cdots \\ \vdots & \vdots & \ddots \end{bmatrix}
-```
+$$
 
 - For $f(x, y) = x^3 + 2xy^2 - y^3$, the gradient is $(3x^2 + 2y^2,\; 4xy - 3y^2)$, and the Hessian is:
 
-```math
+$$
 H = \begin{bmatrix} 6x & 4y \\ 4y & 4x - 6y \end{bmatrix}
-```
+$$
 
 - The diagonal entries ($6x$ and $4x - 6y$) tell you how the slope in the $x$-direction changes as you move in $x$, and similarly for $y$. 
 

--- a/chapter 05: probability/04. bayesian.md
+++ b/chapter 05: probability/04. bayesian.md
@@ -67,9 +67,9 @@ $$P(X_{t+1} | X_t, X_{t-1}, \ldots, X_1) = P(X_{t+1} | X_t)$$
 
 - For the weather example above, the transition matrix is:
 
-```math
+$$
 T = \begin{pmatrix} 0.3 & 0.4 & 0.3 \\ 0.2 & 0.5 & 0.3 \\ 0.4 & 0.3 & 0.3 \end{pmatrix}
-```
+$$
 
 - If today is rainy (state vector $\mathbf{s}_0 = [1, 0, 0]$), the probability distribution over tomorrow's weather is $\mathbf{s}_1 = \mathbf{s}_0 T = [0.3, 0.4, 0.3]$. Two days from now: $\mathbf{s}_2 = \mathbf{s}_0 T^2$. This uses matrix multiplication from Chapter 1.
 

--- a/chapter 07: computational linguistics/02. text processing and classic NLP.md
+++ b/chapter 07: computational linguistics/02. text processing and classic NLP.md
@@ -12,9 +12,9 @@
 
 - Edit distance is computed using dynamic programming (we review in alrothim chapter). Define $D[i][j]$ as the distance between the first $i$ characters of string $s$ and the first $j$ characters of string $t$:
 
-```math
+$$
 D[i][j] = \begin{cases} j & \text{if } i = 0 \\ i & \text{if } j = 0 \\ D[i{-}1][j{-}1] & \text{if } s[i] = t[j] \\ 1 + \min(D[i{-}1][j], \; D[i][j{-}1], \; D[i{-}1][j{-}1]) & \text{otherwise} \end{cases}
-```
+$$
 
 - Edit distance powers spelling correction, fuzzy matching, and DNA sequence alignment. In NLP, it is used to handle typos and find similar words.
 

--- a/chapter 07: computational linguistics/04. transformers and language models.md
+++ b/chapter 07: computational linguistics/04. transformers and language models.md
@@ -18,9 +18,9 @@ $$\text{FFN}(x) = W_2 \cdot \text{GELU}(W_1 x + b_1) + b_2$$
 
 - **Rotary Position Embedding (RoPE)** encodes position by rotating the query and key vectors in 2D subspaces. For a pair of dimensions $(q_{2i}, q_{2i+1})$, the rotation by angle $m\theta_i$ (where $m$ is the position and $\theta_i = 10000^{-2i/d}$) applies:
 
-```math
+$$
 \begin{bmatrix} q'_{2i} \\ q'_{2i+1} \end{bmatrix} = \begin{bmatrix} \cos m\theta_i & -\sin m\theta_i \\ \sin m\theta_i & \cos m\theta_i \end{bmatrix} \begin{bmatrix} q_{2i} \\ q_{2i+1} \end{bmatrix}
-```
+$$
 
 ![RoPE: each position rotates query and key vectors by a different angle in 2D subspaces, so attention scores depend only on relative position](../images/rope_rotation.svg)
 
@@ -202,9 +202,9 @@ $$R_{\text{LCS}} = \frac{\text{LCS}(X, Y)}{m}, \quad P_{\text{LCS}} = \frac{\tex
 
 - **Bits-per-byte** (BPB) normalises by the number of UTF-8 bytes in the text rather than the number of tokens, making it tokenisation-independent:
 
-```math
+$$
 \text{BPB} = \frac{-\sum_{i} \log_2 P(w_i \mid w_{<i})}{\text{number of UTF-8 bytes}}
-```
+$$
 
 - **BERTScore** (Zhang et al., 2020) moves beyond surface-level n-gram matching by computing similarity in embedding space. Each token in the candidate is matched to its most similar token in the reference using cosine similarity of contextual embeddings (typically from a pre-trained BERT model). The scores are aggregated into precision, recall, and F1:
 

--- a/chapter 07: computational linguistics/05. advanced text generation.md
+++ b/chapter 07: computational linguistics/05. advanced text generation.md
@@ -182,9 +182,9 @@ $$\bar{A} = \exp(\Delta A), \quad \bar{B} = (\Delta A)^{-1}(\exp(\Delta A) - I) 
 
 - S4 initialises $A$ using the **HiPPO** (High-order Polynomial Projection Operators) matrix, which is derived from the theory of optimal polynomial approximation of continuous signals. The HiPPO matrix has a specific structure that provably enables the state to maintain a compressed representation of the entire input history with graceful decay:
 
-```math
+$$
 A_{nk} = -\begin{cases} (2n+1)^{1/2}(2k+1)^{1/2} & \text{if } n > k \\ n+1 & \text{if } n = k \\ 0 & \text{if } n < k \end{cases}
-```
+$$
 
 - This lower-triangular structure ensures that the state acts as an online approximation of the input signal using Legendre polynomials. Computing $\bar{A}^k$ for long kernels is expensive, so S4 uses the fact that the HiPPO matrix can be decomposed as a sum of low-rank and diagonal terms, enabling $O(n \log n)$ kernel computation.
 


### PR DESCRIPTION
## Summary
- Replaced all ` ```math ` fenced code blocks with `$$...$$` display math across 12 files (54 blocks total)
- Updates the README contribution guidelines to recommend `$$...$$` instead of ` ```math `
- Equations remain compatible with GitHub rendering while now also rendering correctly in Obsidian