### PR TITLE
Fix MkDocs docs_dir for local serve

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ site_author: "Henry Ndubuaku"
 repo_url: "https://github.com/HenryNdubuaku/maths-cs-ai-compendium"
 repo_name: "HenryNdubuaku/maths-cs-ai-compendium"
 
-docs_dir: docs
+docs_dir: .
 
 theme:
   name: material


### PR DESCRIPTION
## Summary
- point MkDocs at the repository root instead of a missing docs directory
- restore local mkdocs serve support for this checkout

## Testing
- not run (config-only change)