### PR TITLE
fix(mcp): support hyphenated chapter directories

### DIFF
--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = process.env.COMPENDIUM_ROOT || join(__dirname, "..", "..");
 
-const CHAPTER_RE = /^chapter (\d{2}): (.+)$/;
+const CHAPTER_RE = /^chapter (\d{2})(?::| -) (.+)$/;
 const SECTION_RE = /^(\d{2})\. (.+)\.md$/;
 
 interface Chapter {


### PR DESCRIPTION
## Summary

- update `CHAPTER_RE` to recognize both colon- and hyphen-separated chapter directory names
- restore MCP topic discovery after the Windows-compatible directory rename

## Root cause

The chapter directories were renamed from names such as `chapter 01: vectors` to `chapter 01 - vectors`, but the MCP server still matched only the old colon-based format. As a result, `getChapters()` returned an empty array even though the server started successfully, so tools such as `list_topics` and `read_section` could not find any chapter content.

Supporting both separators keeps compatibility with existing clones while recognizing the current directory names.

## Validation

- `./node_modules/.bin/tsc --noEmit --pretty false`
- MCP SDK smoke test confirmed all five tools are exposed and `list_topics({ chapter: 1 })` returns the five vector sections
