### PR TITLE
feat: run Python code in the browser via Pyodide

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -26,6 +26,7 @@ jobs:
           cp README.md docs/index.md
           ln -s ../images docs/images
           ln -s ../javascripts docs/javascripts
+          ln -s ../stylesheets docs/stylesheets
           find . -maxdepth 1 -type d -name 'chapter *' | while IFS= read -r dir; do
             dir="${dir#./}"
             ln -s "../$dir" "docs/$dir"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 site/
 docs/
+.venv/
+mkdocs-local.yml
 mcp/node_modules/
 mcp/package-lock.json
+.cache/

--- a/javascripts/pyodide-runner.js
+++ b/javascripts/pyodide-runner.js
@@ -1,0 +1,353 @@
+(function () {
+  "use strict";
+
+  const PYODIDE_CDN = "https://cdn.jsdelivr.net/pyodide/v0.27.7/full/";
+
+  let pyodideInstance = null;
+  let pyodideLoading = false;
+  let pyodideReady = false;
+  const pendingCallbacks = [];
+
+  async function ensurePyodide(statusCb) {
+    if (pyodideReady) return pyodideInstance;
+
+    if (pyodideLoading) {
+      return new Promise((resolve) => pendingCallbacks.push(resolve));
+    }
+
+    pyodideLoading = true;
+    statusCb("Loading Python runtime…");
+
+    if (typeof loadPyodide === "undefined") {
+      await new Promise((resolve, reject) => {
+        const s = document.createElement("script");
+        s.src = PYODIDE_CDN + "pyodide.js";
+        s.onload = resolve;
+        s.onerror = () => reject(new Error("Failed to load Pyodide"));
+        document.head.appendChild(s);
+      });
+    }
+
+    statusCb("Initialising Python…");
+    pyodideInstance = await loadPyodide({ indexURL: PYODIDE_CDN });
+
+    statusCb("Installing packages…");
+    await pyodideInstance.loadPackage(["numpy", "matplotlib", "micropip"]);
+
+    pyodideInstance.runPython(`
+import matplotlib
+matplotlib.use("AGG")
+import matplotlib.pyplot as plt
+
+import io, base64
+_original_show = plt.show
+def _inline_show(*a, **kw):
+    buf = io.BytesIO()
+    plt.savefig(buf, format="png", dpi=100, bbox_inches="tight",
+                facecolor="#1e1e2e", edgecolor="none")
+    buf.seek(0)
+    _b64 = base64.b64encode(buf.read()).decode()
+    import __main__
+    if not hasattr(__main__, "_plot_outputs"):
+        __main__._plot_outputs = []
+    __main__._plot_outputs.append(_b64)
+    plt.close("all")
+plt.show = _inline_show
+`);
+
+    pyodideInstance.runPython(`
+import sys, types
+import numpy as _np
+
+_jax = types.ModuleType("jax")
+_jax.__package__ = "jax"
+_jax.__path__ = []
+
+def _jit(fn=None, **kw):
+    if fn is None:
+        return lambda f: f
+    return fn
+_jax.jit = _jit
+
+def _grad(fn, argnums=0):
+    eps = 1e-5
+    def grad_fn(*args, **kwargs):
+        idxs = [argnums] if isinstance(argnums, int) else list(argnums)
+        grads = []
+        for idx in idxs:
+            x = _np.asarray(args[idx], dtype=float)
+            g = _np.zeros_like(x)
+            it = _np.nditer(x, flags=["multi_index"])
+            while not it.finished:
+                mi = it.multi_index
+                old = float(x[mi])
+                x[mi] = old + eps
+                a_plus = list(args); a_plus[idx] = x.copy()
+                fp = float(fn(*a_plus, **kwargs))
+                x[mi] = old - eps
+                a_minus = list(args); a_minus[idx] = x.copy()
+                fm = float(fn(*a_minus, **kwargs))
+                g[mi] = (fp - fm) / (2 * eps)
+                x[mi] = old
+                it.iternext()
+            grads.append(g)
+        return grads[0] if isinstance(argnums, int) else tuple(grads)
+    return grad_fn
+_jax.grad = _grad
+
+def _value_and_grad(fn, argnums=0):
+    g_fn = _grad(fn, argnums)
+    def wrapper(*args, **kwargs):
+        return fn(*args, **kwargs), g_fn(*args, **kwargs)
+    return wrapper
+_jax.value_and_grad = _value_and_grad
+
+def _vmap(fn, in_axes=0, out_axes=0):
+    def vmapped(*args):
+        axes = [in_axes] * len(args) if isinstance(in_axes, int) else list(in_axes)
+        batch_size = None
+        for a, ax in zip(args, axes):
+            if ax is not None:
+                batch_size = _np.asarray(a).shape[ax]
+                break
+        results = []
+        for i in range(batch_size):
+            sliced = []
+            for a, ax in zip(args, axes):
+                a = _np.asarray(a)
+                sliced.append(a if ax is None else _np.take(a, i, axis=ax))
+            results.append(fn(*sliced))
+        return _np.stack(results, axis=out_axes)
+    return vmapped
+_jax.vmap = _vmap
+
+def _pmap(fn, **kw):
+    return _vmap(fn)
+_jax.pmap = _pmap
+
+_jnp = types.ModuleType("jax.numpy")
+_jnp.__package__ = "jax"
+for _attr in dir(_np):
+    if not _attr.startswith("__"):
+        setattr(_jnp, _attr, getattr(_np, _attr))
+_jax.numpy = _jnp
+
+_jrandom = types.ModuleType("jax.random")
+_jrandom.__package__ = "jax"
+
+def _PRNGKey(seed):
+    return _np.array([0, seed], dtype=_np.uint32)
+_jrandom.PRNGKey = _PRNGKey
+
+def _split(key, num=2):
+    base = int(key[1])
+    return _np.array([[0, base + i + 1] for i in range(num)], dtype=_np.uint32)
+_jrandom.split = _split
+
+def _normal(key, shape=(), dtype=_np.float32):
+    seed = int(key[1]) if hasattr(key, '__len__') else int(key)
+    return _np.random.RandomState(seed).randn(*shape).astype(dtype)
+_jrandom.normal = _normal
+
+def _uniform(key, shape=(), dtype=_np.float32, minval=0.0, maxval=1.0):
+    seed = int(key[1]) if hasattr(key, '__len__') else int(key)
+    return (_np.random.RandomState(seed).rand(*shape) * (maxval - minval) + minval).astype(dtype)
+_jrandom.uniform = _uniform
+
+def _randint(key, shape, minval, maxval, dtype=_np.int32):
+    seed = int(key[1]) if hasattr(key, '__len__') else int(key)
+    return _np.random.RandomState(seed).randint(minval, maxval, size=shape).astype(dtype)
+_jrandom.randint = _randint
+
+_jax.random = _jrandom
+
+_jnn = types.ModuleType("jax.nn")
+_jnn.__package__ = "jax"
+_jnn.relu = lambda x: _np.maximum(0, x)
+_jnn.sigmoid = lambda x: 1.0 / (1.0 + _np.exp(-_np.clip(x, -500, 500)))
+_jnn.softmax = lambda x, axis=-1: (lambda e: e / e.sum(axis=axis, keepdims=True))(_np.exp(x - x.max(axis=axis, keepdims=True)))
+_jnn.tanh = _np.tanh
+_jnn.log_softmax = lambda x, axis=-1: x - _np.log(_np.exp(x - x.max(axis=axis, keepdims=True)).sum(axis=axis, keepdims=True)) - x.max(axis=axis, keepdims=True)
+_jax.nn = _jnn
+
+_jlax = types.ModuleType("jax.lax")
+_jlax.__package__ = "jax"
+_jlax.dot = lambda a, b: _np.dot(a, b)
+_jax.lax = _jlax
+
+sys.modules["jax"] = _jax
+sys.modules["jax.numpy"] = _jnp
+sys.modules["jax.random"] = _jrandom
+sys.modules["jax.nn"] = _jnn
+sys.modules["jax.lax"] = _jlax
+`);
+
+    pyodideReady = true;
+    pyodideLoading = false;
+    pendingCallbacks.forEach((cb) => cb(pyodideInstance));
+    pendingCallbacks.length = 0;
+    return pyodideInstance;
+  }
+
+  async function runCode(code, outputEl, statusCb) {
+    const pyodide = await ensurePyodide(statusCb);
+    statusCb("Running…");
+
+    outputEl.innerHTML = "";
+
+    pyodide.runPython(`
+import __main__
+__main__._plot_outputs = []
+`);
+
+    pyodide.setStdout({ batched: (t) => appendText(outputEl, t, "stdout") });
+    pyodide.setStderr({ batched: (t) => appendText(outputEl, t, "stderr") });
+
+    try {
+      const needed = detectPackages(code);
+      if (needed.length > 0) {
+        statusCb("Installing packages…");
+        for (const pkg of needed) {
+          try {
+            await pyodide.loadPackage(pkg);
+          } catch {
+            appendText(
+              outputEl,
+              `⚠ Package "${pkg}" is not available in Pyodide.\n`,
+              "stderr"
+            );
+          }
+        }
+        statusCb("Running…");
+      }
+
+      await pyodide.runPythonAsync(code);
+
+      const plots = pyodide.runPython(`
+import __main__
+list(__main__._plot_outputs)
+`);
+      const plotList = plots.toJs();
+      for (const b64 of plotList) {
+        const img = document.createElement("img");
+        img.src = "data:image/png;base64," + b64;
+        img.className = "pyodide-plot";
+        img.alt = "matplotlib output";
+        outputEl.appendChild(img);
+      }
+
+      if (outputEl.children.length === 0 && outputEl.textContent === "") {
+        appendText(outputEl, "✓ Code ran successfully (no output)", "success");
+      }
+    } catch (err) {
+      appendText(outputEl, err.message, "stderr");
+    }
+
+    statusCb("");
+  }
+
+  function appendText(el, text, cls) {
+    const span = document.createElement("span");
+    span.className = "pyodide-" + cls;
+    span.textContent = text + "\n";
+    el.appendChild(span);
+  }
+
+  function detectPackages(code) {
+    const mapping = {
+      scipy: "scipy",
+      sklearn: "scikit-learn",
+      "scikit-learn": "scikit-learn",
+      sympy: "sympy",
+      pandas: "pandas",
+      networkx: "networkx",
+      PIL: "Pillow",
+      cv2: "opencv-python",
+    };
+    const needed = new Set();
+    for (const [token, pkg] of Object.entries(mapping)) {
+      const re = new RegExp(
+        `(?:^|\\s)(?:import|from)\\s+${token.replace("-", "\\-")}`,
+        "m"
+      );
+      if (re.test(code)) needed.add(pkg);
+    }
+    return [...needed];
+  }
+
+  function injectButtons() {
+    const wrappers = document.querySelectorAll(
+      'div.language-python.highlight, div.highlight.language-python'
+    );
+
+    wrappers.forEach((wrapper) => {
+      const pre = wrapper.querySelector("pre");
+      const codeEl = pre && pre.querySelector("code");
+      if (!pre || !codeEl) return;
+      if (wrapper.dataset.pyodideInjected) return;
+      wrapper.dataset.pyodideInjected = "true";
+      injectRunUI(wrapper, pre, codeEl);
+    });
+
+    const standardBlocks = document.querySelectorAll(
+      'pre > code.language-python'
+    );
+    standardBlocks.forEach((codeEl) => {
+      const pre = codeEl.parentElement;
+      if (pre.dataset.pyodideInjected) return;
+      pre.dataset.pyodideInjected = "true";
+
+      const wrapper = document.createElement("div");
+      wrapper.className = "pyodide-wrapper";
+      pre.parentNode.insertBefore(wrapper, pre);
+      wrapper.appendChild(pre);
+      injectRunUI(wrapper, pre, codeEl);
+    });
+  }
+
+  function injectRunUI(wrapper, pre, codeEl) {
+    wrapper.classList.add("pyodide-wrapper");
+
+    const toolbar = document.createElement("div");
+    toolbar.className = "pyodide-toolbar";
+
+    const runBtn = document.createElement("button");
+    runBtn.className = "pyodide-run-btn";
+    runBtn.innerHTML = "▶ <span>Run</span>";
+    runBtn.title = "Execute in browser (Pyodide)";
+
+    const status = document.createElement("span");
+    status.className = "pyodide-status";
+
+    toolbar.appendChild(runBtn);
+    toolbar.appendChild(status);
+    wrapper.appendChild(toolbar);
+
+    const output = document.createElement("pre");
+    output.className = "pyodide-output";
+    output.hidden = true;
+    wrapper.appendChild(output);
+
+    runBtn.addEventListener("click", async () => {
+      runBtn.disabled = true;
+      output.hidden = false;
+      try {
+        await runCode(codeEl.textContent, output, (msg) => {
+          status.textContent = msg;
+        });
+      } finally {
+        runBtn.disabled = false;
+      }
+    });
+  }
+
+  if (typeof document$ !== "undefined") {
+    document$.subscribe(() => injectButtons());
+  } else {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", injectButtons);
+    } else {
+      injectButtons();
+    }
+  }
+})();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ markdown_extensions:
       generic: true
   - pymdownx.highlight:
       anchor_linenums: true
+      pygments_lang_class: true
   - pymdownx.superfences:
       custom_fences:
         - name: math
@@ -56,6 +57,10 @@ markdown_extensions:
 extra_javascript:
   - javascripts/mathjax.js
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
+  - javascripts/pyodide-runner.js
+
+extra_css:
+  - stylesheets/pyodide-runner.css
 
 plugins:
   - search

--- a/stylesheets/pyodide-runner.css
+++ b/stylesheets/pyodide-runner.css
@@ -1,0 +1,130 @@
+.pyodide-wrapper {
+  position: relative;
+  margin: 0.8em 0;
+}
+
+.pyodide-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.75em;
+  padding: 0.35em 0.6em;
+  background: var(--md-code-bg-color, #272822);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 0 0 0.4em 0.4em;
+  font-family: var(--md-code-font-family, "Roboto Mono", monospace);
+  font-size: 0.78rem;
+}
+
+.pyodide-run-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+  padding: 0.3em 0.9em;
+  border: 1px solid rgba(76, 175, 80, 0.4);
+  border-radius: 0.35em;
+  background: rgba(76, 175, 80, 0.12);
+  color: #4caf50;
+  font-family: inherit;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s, transform 0.1s;
+  user-select: none;
+}
+
+.pyodide-run-btn:hover:not(:disabled) {
+  background: rgba(76, 175, 80, 0.25);
+  border-color: rgba(76, 175, 80, 0.7);
+  transform: translateY(-1px);
+}
+
+.pyodide-run-btn:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.pyodide-run-btn:disabled {
+  opacity: 0.5;
+  cursor: wait;
+}
+
+.pyodide-status {
+  color: var(--md-default-fg-color--light, #999);
+  font-style: italic;
+  white-space: nowrap;
+}
+
+.pyodide-output {
+  margin: 0;
+  padding: 0.8em 1em;
+  background: #1a1a2e;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-top: none;
+  border-radius: 0 0 0.4em 0.4em;
+  font-family: var(--md-code-font-family, "Roboto Mono", monospace);
+  font-size: 0.82rem;
+  line-height: 1.55;
+  overflow-x: auto;
+  max-height: 500px;
+  overflow-y: auto;
+}
+
+.pyodide-output .pyodide-stdout {
+  color: #e0e0e0;
+}
+
+.pyodide-output .pyodide-stderr {
+  color: #ff6b6b;
+}
+
+.pyodide-output .pyodide-success {
+  color: #69db7c;
+}
+
+.pyodide-output .pyodide-plot {
+  display: block;
+  max-width: 100%;
+  margin: 0.5em 0;
+  border-radius: 0.4em;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.pyodide-wrapper .pyodide-toolbar:has(+ .pyodide-output:not([hidden])) {
+  border-radius: 0;
+}
+
+[data-md-color-scheme="default"] .pyodide-output {
+  background: #f5f5f5;
+  border-color: rgba(0, 0, 0, 0.08);
+}
+
+[data-md-color-scheme="default"] .pyodide-output .pyodide-stdout {
+  color: #333;
+}
+
+[data-md-color-scheme="default"] .pyodide-output .pyodide-stderr {
+  color: #d32f2f;
+}
+
+[data-md-color-scheme="default"] .pyodide-output .pyodide-success {
+  color: #2e7d32;
+}
+
+[data-md-color-scheme="default"] .pyodide-toolbar {
+  background: var(--md-code-bg-color, #f5f5f5);
+  border-top-color: rgba(0, 0, 0, 0.06);
+}
+
+[data-md-color-scheme="default"] .pyodide-run-btn {
+  border-color: rgba(46, 125, 50, 0.3);
+  background: rgba(46, 125, 50, 0.08);
+  color: #2e7d32;
+}
+
+[data-md-color-scheme="default"] .pyodide-run-btn:hover:not(:disabled) {
+  background: rgba(46, 125, 50, 0.18);
+  border-color: rgba(46, 125, 50, 0.5);
+}
+
+[data-md-color-scheme="default"] .pyodide-output .pyodide-plot {
+  border-color: rgba(0, 0, 0, 0.08);
+}


### PR DESCRIPTION
## What

Adds a **▶ Run** button to every Python code block in the compendium, letting readers execute code directly in the browser — zero local setup needed.

**Powered by [Pyodide](https://pyodide.org/)** (CPython compiled to WebAssembly), inspired by [hemanth/pylab](https://github.com/hemanth/pylab).

## Demo

Every `python` fenced code block automatically gets a run button. Clicking it:
1. Lazy-loads the Pyodide runtime (~10 MB WASM, cached after first load)
2. Installs numpy + matplotlib + any detected packages
3. Executes the code and shows stdout/stderr inline
4. Renders matplotlib plots as inline images

## JAX Compatibility

The compendium uses `import jax.numpy as jnp` extensively. Since JAX is too heavy for WASM, a full compatibility shim is included:
- `jax.numpy` → aliases to numpy
- `jax.grad` → numerical gradient via central finite differences
- `jax.vmap` → loop-based vectorised map
- `jax.jit` → no-op pass-through
- `jax.random` → numpy.random with JAX-style `PRNGKey` / `split` API
- `jax.nn` → relu, sigmoid, softmax, etc.

## Files changed

| File | Change |
|------|--------|
| `javascripts/pyodide-runner.js` | **New** — Pyodide runtime, ▶ Run buttons, JAX shim, matplotlib inline |
| `stylesheets/pyodide-runner.css` | **New** — Dark/light themed UI for run button + output |
| `mkdocs.yml` | Added JS + CSS refs, enabled `pygments_lang_class` |
| `.github/workflows/deploy-docs.yml` | Symlinks `stylesheets/` into `docs/` |
| `.gitignore` | Added `.venv/`, `.cache/`, `mkdocs-local.yml` |

## Limitations

- C++/CUDA/bash code blocks are left untouched (only Python runs)
- Heavy packages (torch, tensorflow) are not available in Pyodide
- JAX shim uses finite differences, not symbolic autodiff

## Deploy

Works with the existing `gh-deploy` workflow — no changes to the build pipeline needed. The `stylesheets/` directory is symlinked alongside `javascripts/` and `images/`.

---

<img width="1527" height="897" alt="image" src="https://github.com/user-attachments/assets/e4de2531-d947-485d-8c63-c418ab1b5a00" />

<img width="1647" height="1637" alt="image" src="https://github.com/user-attachments/assets/a0a9181f-0731-46f2-8707-e316a1a2d37b" />

