### PR TITLE
docs: add 简体中文 reading link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="images/logo.png" alt="Logo" style="border-radius: 30px; width: 100%;">
 
-**Read online**: [henryndubuaku.github.io/maths-cs-ai-compendium](https://henryndubuaku.github.io/maths-cs-ai-compendium/)
+**Read online**: [henryndubuaku.github.io/maths-cs-ai-compendium](https://henryndubuaku.github.io/maths-cs-ai-compendium/) | [简体中文](https://godlockin.github.io/maths-cs-ai-compendium/zh/)
 
 <a href="https://trendshift.io/repositories/21344?utm_source=repository-badge&amp;utm_medium=badge&amp;utm_campaign=badge-repository-21344" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/repositories/21344" alt="HenryNdubuaku%2Fmaths-cs-ai-compendium | Trendshift" width="250" height="55"/></a>
 


### PR DESCRIPTION
This PR adds a direct link to the Simplified Chinese translation hosted at
[godlockin.github.io/maths-cs-ai-compendium/zh/](https://godlockin.github.io/maths-cs-ai-compendium/zh/).

Helps Chinese-speaking readers discover the translation without needing
to know about the separate community fork.

The translation currently covers all 25 chapters plus teaching materials
(讲义、思维导图、信息图、复习大纲、面试指南、配套图等).

Link is placed next to the existing English online reading link.